### PR TITLE
update Helm provider version constraint to >= 2.10.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.10.0"
+      version = ">= 2.10.0"
     }
 
     kubectl = {


### PR DESCRIPTION
**Description**
Update the Helm provider version constraint from `~> 2.10.0` to `>= 2.10.0` to enable the use of any future versions beyond 2.10.0.