### PR TITLE
Move to strict type variables

### DIFF
--- a/chkkagent.tftpl
+++ b/chkkagent.tftpl
@@ -10,26 +10,30 @@ ${yamlencode({
         contains(keys(filter), "rules") ? { 
             "filter": yamlencode(filter),
             } : {},
-        contains(keys(chkk_agent_config.secret), "accessToken") ? {
-            "credentials": {
-                "accessToken": chkk_agent_config.secret.accessToken,
-            },
-            } : {},
-        contains(keys(chkk_agent_config.secret), "keyName") && contains(keys(chkk_agent_config.secret), "secretName") ? {
-            "credentials": {
-                "accessTokenSecret": {
-                    "keyName": chkk_agent_config.secret.keyName,
-                    "secretName": chkk_agent_config.secret.secretName,
+        chkk_agent_config.secret != null ?
+            contains(keys(chkk_agent_config.secret), "accessToken") ? {
+                "credentials": {
+                    "accessToken": chkk_agent_config.secret.accessToken,
                 },
-            },
-            } : {},
+                } : {}
+            : {},
+        chkk_agent_config.secret != null ? 
+            contains(keys(chkk_agent_config.secret), "keyName") && contains(keys(chkk_agent_config.secret), "secretName") ? {
+                "credentials": {
+                    "accessTokenSecret": {
+                        "keyName": chkk_agent_config.secret.keyName,
+                        "secretName": chkk_agent_config.secret.secretName,
+                    },
+                },
+                } : {}
+            : {},
         ),
     "agentOverride":  merge(
                 contains(keys(chkk_agent_config.serviceAccount), "create") ?
                     {
                         "createRbac": chkk_agent_config.serviceAccount.create,
                     } : {},
-                contains(keys(chkk_agent_config.serviceAccount), "serviceAccountName") ? 
+                contains(keys(chkk_agent_config.serviceAccount), "name") ? 
                     { 
                         "serviceAccountName": chkk_agent_config.serviceAccount.name,
                     } : {},

--- a/variables.tf
+++ b/variables.tf
@@ -24,15 +24,22 @@ variable "filter" {
 
 variable "chkk_operator_config" {
   description = "Values for the chkk-operator Helm chart"
-  type        = map(any)
   default     = {}
 }
 
 variable "chkk_agent_config" {
   description = "Override the default chkk-agent config"
-  type        = map(any)
-  default = {
-    "serviceAccount" = {}
-    "secret"         = {}
-  }
+  type = object({
+    secret = optional(object({
+      secretName = string
+      keyName    = string
+    }))
+    serviceAccount = optional(object({
+      create = bool
+      name   = optional(string)
+      }), {
+      create = true
+    })
+  })
+  default = {}
 }


### PR DESCRIPTION
**Description**

- Move to strict type variables to better align with Chkk Operator helm chart values. This helps creates objects which have different value types compared to the map type which only allows single value type.
- Update ChkkAgent template to check for `name` instead of `serviceAccountName` for workflows with existing service accounts.