### PR TITLE
Add terraform variable to manage chart_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following snippet will deploy the Chkk Operator with the specified access to
 
 ```
 module "chkk_k8s_connector" {
-  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.3"
+  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.4"
 
   create_namespace = true
   namespace        = "chkk-system"
@@ -32,7 +32,7 @@ The following snippet will deploy the Chkk Operator using the `chkk-operator-sec
 
 ```
 module "chkk_k8s_connector" {
-  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.3"
+  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.4"
 
   create_namespace = true
   namespace        = "chkk-system"
@@ -53,7 +53,7 @@ The following snippet will deploy the Chkk Operator using the `chkk-operator-sec
 
 ```
 module "chkk_k8s_connector" {
-  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.3"
+  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.4"
 
   create_namespace = true
   namespace        = "chkk-system"
@@ -81,7 +81,7 @@ The following snippet will deploy the Chkk Operator with the specified access to
 
 ```
 module "chkk_k8s_connector" {
-  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.3"
+  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.4"
 
   create_namespace = true
   namespace        = "chkk-system"
@@ -102,7 +102,7 @@ The following snippet will deploy the Chkk Operator with the specified access to
 
 ```
 module "chkk_k8s_connector" {
-  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.3"
+  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.4"
 
   create_namespace = true
   namespace        = "chkk-system"
@@ -130,7 +130,7 @@ The following snippet will deploy the Chkk Operator with the specified access to
 
 ```
 module "chkk_k8s_connector" {
-  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.3"
+  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.4"
 
   create_namespace = true
   namespace        = "chkk-system"
@@ -154,6 +154,7 @@ The module accepts following variables: <br>
 |------|-------------|------|---------|:--------:|
 | release_name | The name of the helm release | `string` | chkk-operator | no |
 | namespace | The namespace to deploy resources | `string` | chkk-system | no |
+| chart_version | The version of the helm chart to deploy | `string` | n/a | no |
 | create\_namespace | Whether to create namespace if it doesn't exist | `bool` | true | no |
 | filter | Override the default filter for the ChkkAgent| `string` | n\a | no |
 | cluster_name | Override the default cluster name for the ChkkAgent | `string` | n\a | no |

--- a/helm.tf
+++ b/helm.tf
@@ -4,10 +4,11 @@ resource "helm_release" "chkk_operator" {
   name             = var.release_name
   repository       = "https://helm.chkk.io"
   chart            = "chkk-operator"
+  version          = var.chart_version != "" ? var.chart_version : null
   namespace        = var.namespace
   create_namespace = var.create_namespace
 
-   values = [
+  values = [
     yamlencode(var.chkk_operator_config)
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "namespace" {
   default     = "chkk-system"
 }
 
+variable "chart_version" {
+  description = "Version of the Helm chart"
+  type        = string
+  default     = ""
+}
+
 variable "create_namespace" {
   description = "Create the namespace if it does not exist."
   type        = bool


### PR DESCRIPTION
**Description**
This is required to manage upgrades of the helm_release. If no value is provided, the helm provider uses the latest version but it does not upgrade the current installed version to the latest one. So in order to manage it manually, you can either delete and re-create the resource or use the newly introduced `chart_version` field to update to the desired chart_version.