### PR TITLE
Added support for custom agent and manager images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Editor directories
+.cursor/
+.vscode/
+.terraform/

--- a/README.md
+++ b/README.md
@@ -152,17 +152,15 @@ The following snippet will deploy the Chkk Kubernetes Connector with custom imag
 module "chkk_k8s_connector" {
   source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.4"
 
-  create_namespace = true      # don't spam your real cluster during dry-run
+  create_namespace = true     
   namespace        = "chkk-system"
 
   chkk_agent_config = {
     agent_image = {
-      repository = "public.ecr.aws/chkk/cluster-agent"
-      tag        = "v0.1.10"
+      repository = "public.ecr.aws/chkk/cluster-agent:v0.1.10"
     }
     manager_image = {
-      repository = "public.ecr.aws/chkk/cluster-agent-manager"
-      tag        = "v0.1.10"
+      name = "public.ecr.aws/chkk/cluster-agent-manager:v0.1.10"
     }
   }
 
@@ -209,11 +207,9 @@ The module accepts following variables: <br>
 | chkk\_agent_\_config.serviceAccount.create | Whether to create RBAC (Service Account, Role, etc) for ChkkAgent or use an existing resource | `boolean` | true | no |
 | chkk\_agent_\_config.serviceAccount.serviceAccountName | If create is false, this should be the name of the existing Service Account | `string` | "" | no |
 | chkk\_agent_\_config.agent_image | Agent Image object for ChkkAgent | `map` | {} | no |
-| chkk\_agent_\_config.agent_image.repository | Repository for the agent image | `string` | "" | no |
-| chkk\_agent_\_config.agent_image.tag | Tag for the agent image | `string` | "" | no |
+| chkk\_agent_\_config.agent_image.name | Full image name for the agent image (repository:tag) | `string` | "" | no |
 | chkk\_agent_\_config.manager_image | Manager Image object for ChkkAgent | `map` | {} | no |
-| chkk\_agent_\_config.manager_image.repository | Repository for the manager image | `string` | "" | no |
-| chkk\_agent_\_config.manager_image.tag | Tag for the manager image | `string` | "" | no |
+| chkk\_agent_\_config.manager_image.name | Full image name for the manager image (repository:tag) | `string` | "" | no |
 
 ## Outputs
 No output.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,38 @@ module "chkk_k8s_connector" {
 }
 ```
 
+The following snippet will deploy the Chkk Kubernetes Connector with custom images for: Chkk Operator, Chkk Agent, and Chkk Agent Manager. 
+
+```
+module "chkk_k8s_connector" {
+  source     = "git::https://github.com/chkk-io/terraform-chkk-k8s-connector.git?ref=v0.1.4"
+
+  create_namespace = true      # don't spam your real cluster during dry-run
+  namespace        = "chkk-system"
+
+  chkk_agent_config = {
+    agent_image = {
+      repository = "public.ecr.aws/chkk/cluster-agent"
+      tag        = "v0.1.10"
+    }
+    manager_image = {
+      repository = "public.ecr.aws/chkk/cluster-agent-manager"
+      tag        = "v0.1.10"
+    }
+  }
+
+  chkk_operator_config = {
+    secret = {
+      chkkAccessToken = <TOKEN>
+    }
+    image = {
+      repository = "public.ecr.aws/chkk/operator"
+      tag        = "v0.0.10"
+    }
+  }
+}
+```
+
 For a complete reference, see the section below.
 
 ## Inputs
@@ -176,6 +208,12 @@ The module accepts following variables: <br>
 | chkk\_agent_\_config.serviceAccount | Service Account object for ChkkAgent | `map` | {} | no |
 | chkk\_agent_\_config.serviceAccount.create | Whether to create RBAC (Service Account, Role, etc) for ChkkAgent or use an existing resource | `boolean` | true | no |
 | chkk\_agent_\_config.serviceAccount.serviceAccountName | If create is false, this should be the name of the existing Service Account | `string` | "" | no |
+| chkk\_agent_\_config.agent_image | Agent Image object for ChkkAgent | `map` | {} | no |
+| chkk\_agent_\_config.agent_image.repository | Repository for the agent image | `string` | "" | no |
+| chkk\_agent_\_config.agent_image.tag | Tag for the agent image | `string` | "" | no |
+| chkk\_agent_\_config.manager_image | Manager Image object for ChkkAgent | `map` | {} | no |
+| chkk\_agent_\_config.manager_image.repository | Repository for the manager image | `string` | "" | no |
+| chkk\_agent_\_config.manager_image.tag | Tag for the manager image | `string` | "" | no |
 
 ## Outputs
 No output.

--- a/chkkagent.tftpl
+++ b/chkkagent.tftpl
@@ -35,14 +35,60 @@ ${yamlencode({
             } : {},
         ),
     "agentOverride":  merge(
-                contains(keys(chkk_agent_config.serviceAccount), "create") ?
-                    {
-                        "createRbac": chkk_agent_config.serviceAccount.create,
-                    } : {},
-                contains(keys(chkk_agent_config.serviceAccount), "name") ? 
-                    { 
-                        "serviceAccountName": chkk_agent_config.serviceAccount.name,
-                    } : {},
-                 )
+            contains(keys(chkk_agent_config.serviceAccount), "create") ?
+                {
+                    "createRbac": chkk_agent_config.serviceAccount.create,
+                } : {},
+            contains(keys(chkk_agent_config.serviceAccount), "name") ? 
+                { 
+                    "serviceAccountName": chkk_agent_config.serviceAccount.name,
+                } : {},
+
+            # ── custom agent image ──
+            contains(keys(chkk_agent_config), "agent_image") ? 
+                chkk_agent_config.agent_image != null ? 
+                    contains(keys(chkk_agent_config.agent_image), "repository") ? 
+                        contains(keys(chkk_agent_config.agent_image), "tag") ?
+                            chkk_agent_config.agent_image.repository != null ?
+                                chkk_agent_config.agent_image.repository != "" ?
+                                    chkk_agent_config.agent_image.tag != null ?
+                                        chkk_agent_config.agent_image.tag != "" ?
+                                            {
+                                                "image": {
+                                                    "name": "${chkk_agent_config.agent_image.repository}:${chkk_agent_config.agent_image.tag}"
+                                                }
+                                            }
+                                        : {}
+                                    : {}
+                                : {}
+                            : {}
+                        : {}
+                    : {}
+                : {}
+            : {},
+
+            # ── custom manager image ──
+            contains(keys(chkk_agent_config), "manager_image") ? 
+                chkk_agent_config.manager_image != null ? 
+                    contains(keys(chkk_agent_config.manager_image), "repository") ? 
+                        contains(keys(chkk_agent_config.manager_image), "tag") ?
+                            chkk_agent_config.manager_image.repository != null ?
+                                chkk_agent_config.manager_image.repository != "" ?
+                                    chkk_agent_config.manager_image.tag != null ?
+                                        chkk_agent_config.manager_image.tag != "" ?
+                                            {
+                                                "managerImage": {
+                                                    "name": "${chkk_agent_config.manager_image.repository}:${chkk_agent_config.manager_image.tag}"
+                                                }
+                                            }
+                                        : {}
+                                    : {}
+                                : {}
+                            : {}
+                        : {}
+                    : {}
+                : {}
+            : {}
+        )
     }
 })}

--- a/chkkagent.tftpl
+++ b/chkkagent.tftpl
@@ -46,49 +46,33 @@ ${yamlencode({
 
             # ── custom agent image ──
             contains(keys(chkk_agent_config), "agent_image") ? 
-                chkk_agent_config.agent_image != null ? 
-                    contains(keys(chkk_agent_config.agent_image), "repository") ? 
-                        contains(keys(chkk_agent_config.agent_image), "tag") ?
-                            chkk_agent_config.agent_image.repository != null ?
-                                chkk_agent_config.agent_image.repository != "" ?
-                                    chkk_agent_config.agent_image.tag != null ?
-                                        chkk_agent_config.agent_image.tag != "" ?
-                                            {
-                                                "image": {
-                                                    "name": "${chkk_agent_config.agent_image.repository}:${chkk_agent_config.agent_image.tag}"
-                                                }
-                                            }
-                                        : {}
-                                    : {}
-                                : {}
-                            : {}
+                chkk_agent_config.agent_image != null ?
+                    contains(keys(chkk_agent_config.agent_image), "name") ?
+                        chkk_agent_config.agent_image.name != null ?
+                            {
+                                "image": {
+                                    "name": chkk_agent_config.agent_image.name
+                                }
+                            } 
                         : {}
-                    : {}
+                    : {} 
                 : {}
             : {},
 
             # ── custom manager image ──
             contains(keys(chkk_agent_config), "manager_image") ? 
-                chkk_agent_config.manager_image != null ? 
-                    contains(keys(chkk_agent_config.manager_image), "repository") ? 
-                        contains(keys(chkk_agent_config.manager_image), "tag") ?
-                            chkk_agent_config.manager_image.repository != null ?
-                                chkk_agent_config.manager_image.repository != "" ?
-                                    chkk_agent_config.manager_image.tag != null ?
-                                        chkk_agent_config.manager_image.tag != "" ?
-                                            {
-                                                "managerImage": {
-                                                    "name": "${chkk_agent_config.manager_image.repository}:${chkk_agent_config.manager_image.tag}"
-                                                }
-                                            }
-                                        : {}
-                                    : {}
-                                : {}
-                            : {}
+                chkk_agent_config.manager_image != null ?
+                    contains(keys(chkk_agent_config.manager_image), "name") ?
+                        chkk_agent_config.manager_image.name != null ?
+                            {
+                                "managerImage": {
+                                    "name": chkk_agent_config.manager_image.name
+                                }
+                            } 
                         : {}
-                    : {}
+                    : {} 
                 : {}
-            : {}
+            : {},
         )
     }
 })}

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,14 @@ variable "chkk_agent_config" {
       }), {
       create = true
     })
+    agent_image = optional(object({
+      repository = string
+      tag        = string
+    }))
+    manager_image = optional(object({
+      repository = string
+      tag        = string
+    }))
   })
   default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,12 +47,10 @@ variable "chkk_agent_config" {
       create = true
     })
     agent_image = optional(object({
-      repository = string
-      tag        = string
+      name = string
     }))
     manager_image = optional(object({
-      repository = string
-      tag        = string
+      name = string
     }))
   })
   default = {}


### PR DESCRIPTION
This change enhances the Terraform module to support customization of images used for the Chkk Agent and Chkk Agent Manager. The update includes:

- Added new configuration options in `variables.tf` for specifying custom agent and manager image repositories and tags
- Updated the `chkkagent.tftpl` template to properly handle and apply these custom image configurations
- Enhanced the README.md with documentation and a new usage example showing how to deploy the Chkk Kubernetes Connector with custom images

These improvements allow users to specify their own container images when necessary, providing greater flexibility for environments with specific requirements or private registries.

## Testing

<details>
<summary>1. Created a `main.tf` file with custom Operator, Agent Manager and Agent images. Pointed the source to my local repository</summary>

```yaml
module "chkk_k8s_connector" {
  # local path to the repo you're editing
  source = "/Users/moons/Desktop/chkk/repos/terraform-chkk-k8s-connector"

  create_namespace = true      # don't spam your real cluster during dry-run
  namespace        = "chkk-system"

  chkk_agent_config = {
    agent_image = {
      repository = "public.ecr.aws/chkk/cluster-agent"
      tag        = "v0.1.10"
    }
    manager_image = {
      repository = "public.ecr.aws/chkk/cluster-agent-manager"
      tag        = "v0.1.10"
    }
  }

  chkk_operator_config = {
    secret = {
      chkkAccessToken = <TOKEN>
    }
    image = {
      repository = "public.ecr.aws/chkk/operator"
      tag        = "v0.0.10"
    }
  }
}
```

</details>

<details>
<summary>2. Created a `kubernetes.tf`</summary>

```yaml
provider "kubernetes" {
  config_path    = "~/.kube/config"  # Path to your kubeconfig file
  config_context = "kind-kind"       # Using the current context detected
}

provider "kubectl" {
  config_path    = "~/.kube/config"
  config_context = "kind-kind"
}

provider "helm" {
  kubernetes {
    config_path    = "~/.kube/config"
    config_context = "kind-kind"
  }
} 
```

</details>

<details>
<summary>3. Create a `versions.tf`</summary>

```yaml
terraform {
  required_version = ">= 1.5.0"
  required_providers {
    helm     = { source = "hashicorp/helm",     version = ">= 2.10.0" }
    kubectl  = { source = "gavinbunney/kubectl", version = ">= 1.7.0" }
  }
}
```

</details>

4. Created a kind cluster: `kind create cluster`
5. Ran `terraform init` to initialise Terraform
6. Ran `terraform validate` to validate Chart
7. Run `terraform plan` to create a plan
8. Run `terraform apply` to apply the custom configuration
9. Validate all of the images once the Terraform configurations have been applied

```bash
➜  chkk-tpl-test k get -n chkk-system -o yaml cronjob.batch/chkk-agent-cron | grep image:
            image: public.ecr.aws/chkk/cluster-agent:v0.1.10
➜  chkk-tpl-test k get -n chkk-system -o yaml deployment.apps/chkk-operator | grep image:
        image: public.ecr.aws/chkk/operator:v0.0.10
➜  chkk-tpl-test k get -n chkk-system -o yaml deployment.apps/chkk-agent-manager | grep image:
        image: public.ecr.aws/chkk/cluster-agent-manager:v0.1.10
```

